### PR TITLE
Stop hard-coding log group in container initialization script

### DIFF
--- a/CassandraCluster.yml
+++ b/CassandraCluster.yml
@@ -514,7 +514,7 @@ Resources:
                 
                 # launch cassandra
                 docker run -d --privileged --name cassandra --restart always --network=host -u $(id -u cassandra) \
-                --log-driver=awslogs --log-opt awslogs-region="${AWS::Region}" --log-opt awslogs-group="dev-cassandra-test" --log-opt awslogs-stream="node$NODE_ID" \
+                --log-driver=awslogs --log-opt awslogs-region="${AWS::Region}" --log-opt awslogs-group="${AWS::StackName}" --log-opt awslogs-stream="node$NODE_ID" \
                 -e CASSANDRA_SEEDS="$SEED_IP" \
                 -e CASSANDRA_BROADCAST_ADDRESS="$NODE_ADDRESS" \
                 -v $mount_path/cassandra/node$NODE_ID:/var/lib/cassandra \


### PR DESCRIPTION
The log group was hard-coded to `dev-cassandra-test` so if you created a CF stack with a different name, the container would fail to initialize correctly (and the ASG would not be signaled) because the log group did not exist. Since the log group is based off the stack name, use the stack name. 

**Note:** I would prefer to reference the `LogGroup` Resource directly if possible since this is still a hack