### PR TITLE
Enable rack-awareness

### DIFF
--- a/CassandraCluster.yml
+++ b/CassandraCluster.yml
@@ -509,7 +509,9 @@ Resources:
                 # retrieve cassandra config files
                 mkdir -p /etc/cassandra
                 chmod 755 /etc/cassandra
+                echo "Downloading Cassandra configuration files from S3" >> /var/log/setup.log
                 aws s3 sync s3://cassandra-configuration/${AWS::StackName} /etc/cassandra
+                echo "Finished downloading Cassandra configuration files from S3" >> /var/log/setup.log
                 chown -R cassandra:cassandra /etc/cassandra
                 chmod -R 644 /etc/cassandra/*
                 
@@ -529,6 +531,7 @@ Resources:
                 --log-driver=awslogs --log-opt awslogs-region="${AWS::Region}" --log-opt awslogs-group="${LogGroup}" --log-opt awslogs-stream="node$NODE_ID" \
                 -e CASSANDRA_SEEDS="$SEED_IP" \
                 -e CASSANDRA_BROADCAST_ADDRESS="$NODE_ADDRESS" \
+                -e CASSANDRA_ENDPOINT_SNITCH="org.apache.cassandra.locator.Ec2Snitch" \
                 -v $node_folder:/var/lib/cassandra \
                 -v /etc/cassandra:/etc/cassandra cassandra:3.11 >> /var/log/docker                    
           commands:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Cassandra AWS
 
-## Generating a KeyStore and TrustStore
+## Architecture
+This CloudFormation template deploys a multi-node (3 node) Cassandra cluster in a single AWS region (C* datacenter) 
+across multiple Availability Zones (multiple C* racks).
+
+## Generating a KeyStore and TrustStore for Node-to-Node and Client-to-Node encryption
 
 Run the truststore-setup script and specify the password and cluster name.
 
@@ -25,3 +29,6 @@ Sync the s3 bucket holding the Cassandra configuration and certs.
 ```
 aws s3 sync cassandra-config s3://cassandra-configuration/<clustername>
 ```
+
+**Note:** You must name the CloudFormation stack exactly the same as `<clustername>` defined above in order for 
+encryption to work correctly.


### PR DESCRIPTION
Deployments are now rack aware using the `EC2Snitch`
- single C* data center (AWS region)
- multi C* rack (AWS multi-AZs)
- added debug statements for S3 that go to setup.log for tracking purposes
- minor documentation improvements